### PR TITLE
add js to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -59,6 +59,14 @@
           }
         }
       ]
+    },
+    "js": {
+      "transformGroup": "js",
+      "buildPath": "build/js/",
+      "files": [{
+        "destination": "variables.js",
+        "format": "javascript/es6"
+      }]
     }
   }
 }


### PR DESCRIPTION
Just adding an additional `js` platform to build to.

Sass -> js transformers do exist but we can remove this necessity by simply exporting to the additional format.